### PR TITLE
Use a projection to avoid fetching all fields

### DIFF
--- a/lib/Apache/Session/MongoDB.pm
+++ b/lib/Apache/Session/MongoDB.pm
@@ -33,6 +33,7 @@ our $default;
 1;
 
 __END__
+
 sub searchOn {
     my ( $class, $args, $selectField, $value, @fields ) = @_;
     return $class->_query( $args, { $selectField => $value }, @fields );
@@ -49,16 +50,15 @@ sub _query {
     my ( $class, $args, $filter, @fields ) = @_;
     my $col    = $class->_col($args);
     my $cursor = $col->find($filter);
+    if (@fields) {
+        $cursor =
+          $cursor->fields( { map { $_ => 1 } @fields, "_session_id" => 1 } );
+    }
     my $res;
     while ( my $r = $cursor->next ) {
         my $id = $r->{_session_id};
         delete $r->{_id};
-        if (@fields) {
-            $res->{$id}->{$_} = $r->{$_} foreach (@fields);
-        }
-        else {
-            $res->{$id} = $r;
-        }
+        $res->{$id} = $r;
     }
     return $res;
 }


### PR DESCRIPTION
MongoDB gives us the ability to express which fields we are interested in when running a query. Which is exactly what the `@fields` array is for. 

This changes modifies the cursor to only select interesting fields. This gives a very nice performance boost on the perl side (3s => 1s to fetch 50k sessions in LemonLDAP's session browser), makes bandwidth to the mongo server much lower, and it also allow MongoDB to use a [covered query](https://docs.mongodb.com/manual/core/query-optimization/#covered-query) if its indexes allow it.