### PR TITLE
Fix behavior when a session is not found

### DIFF
--- a/lib/Apache/Session/Store/MongoDB.pm
+++ b/lib/Apache/Session/Store/MongoDB.pm
@@ -69,7 +69,7 @@ sub materialize {
         $session->{data}->{_session_id} = $session->{data}->{_id};
     }
     else {
-        $session->data = undef;
+        die "Object does not exist in the data store";
     }
 }
 


### PR DESCRIPTION
Apache::Session modules are supposed to die when they cannot find a session, instead of returning undef (a46b17a58ff57415d450184d6e665ea14862daba)

Thankfully, a typo in the code means they still die, with the following message:

```
Session cannot be tied: Can't modify non-lvalue subroutine call of &AutoLoader::AUTOLOAD at /usr/local/share/perl/5.26.1/Apache/Session/Store/MongoDB.pm line 72
```

Attempting to fix the typo breaks LemonLDAP::NG::Common::Session :

```
my $var = {
	'storageModuleOptions' => {
		'db_name' => 'sessions',
		'collection' => 'psessions',
	},
	'kind' => 'Persistent',
	'storageModule' => 'Apache::Session::MongoDB',
	'id' => '5efe8af397fc3577e05b483aca964f1c',
	'force' => 1,
	'info' => {
		'_loginHistory' => {
			'successLogin' => [
				{
					'_utime' => 1616505142,
					'ipAddr' => '127.0.0.1'
				}
			]
		},
		'_updateTime' => '20210323131222',
		'_session_uid' => 'dwho'
	}
};

my $ps = Lemonldap::NG::Common::Session->new($var);
use Data::Dumper;
print Dumper($ps);
```

(no session is created)